### PR TITLE
Moving plugin to the top in config file

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,6 +7,14 @@ module.exports = {
   },
   plugins: [
     {
+      resolve: `gatsby-plugin-google-analytics`,
+      options: {
+        trackingId: "UA-85442279-5",
+        head: true,
+        anonymize: true,
+      }
+    },
+    {
       resolve: `gatsby-source-filesystem`,
       options: {
         path: `${__dirname}/../blog`,
@@ -37,20 +45,6 @@ module.exports = {
     },
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
-    {
-      resolve: `gatsby-plugin-google-analytics`,
-      options: {
-        trackingId: "UA-85442279-5",
-        // Puts tracking script in the head instead of the body
-        head: false,
-        // Setting this parameter is optional
-        anonymize: true,
-        // Setting this parameter is also optional
-        respectDNT: true,
-        sampleRate: 5,
-        siteSpeedSampleRate: 10
-      }
-    },
     `gatsby-plugin-feed`,
     `gatsby-plugin-offline`,
     `gatsby-plugin-react-helmet`,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "gatsby": "^2.20.0",
     "gatsby-image": "^2.0.22",
     "gatsby-plugin-feed": "^2.0.8",
-    "gatsby-plugin-google-analytics": "^2.0.5",
+    "gatsby-plugin-google-analytics": "^2.2.0",
     "gatsby-plugin-manifest": "^2.0.5",
     "gatsby-plugin-offline": "^2.0.5",
     "gatsby-plugin-react-helmet": "^3.0.0",


### PR DESCRIPTION
- Bumping Google Analytics version
- Moving plugin to the top of `gatsby-config.js` file per Troubleshooting guidance here: https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-google-analytics#readme